### PR TITLE
fixed dependencies for compilation of tests from module provider-example

### DIFF
--- a/provider-example/pom.xml
+++ b/provider-example/pom.xml
@@ -11,7 +11,19 @@
   <packaging>war</packaging>
   <name>OAuth2::Examples::Provider webapp</name>
   <dependencies>
-      <dependency>
+    <dependency>
+      <groupId>org.mortbay.jetty</groupId>
+      <artifactId>jetty-servlet-tester</artifactId>
+      <version>6.1.0</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mortbay.jetty</groupId>
+      <artifactId>jsp-2.1</artifactId>
+      <version>6.1.11</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
           <version>3.8.2</version>


### PR DESCRIPTION
I have been unable to compile the tests of the provider-example module because two dependencies (jetty-servlet-tester and jetty-jsp) have been missing. I've added the dependencies to the pom and compilation and tests run fine.
